### PR TITLE
Update deviceview.html to correct malformed int.stylename value in st…

### DIFF
--- a/netbox_device_view/templates/netbox_device_view/deviceview.html
+++ b/netbox_device_view/templates/netbox_device_view/deviceview.html
@@ -59,12 +59,7 @@
 					{% endif %}
 					{% endfor %}
 				{% endif %}
-				"
-				style="grid-area: {{ int.stylename }};
-				{% if cable_colors == "on" and int.cable.color != "" %}
-				background-color: #{{ int.cable.color }}
-				{% endif %}
-				"
+				style="grid-area: {{ int.stylename }}{% if cable_colors == 'on' and int.cable.color != '' %}; background-color: #{{ int.cable.color }}{% endif %}"
 				data-bs-toggle="tooltip"
 				data-bs-html="true"
 				data-bs-custom-class="device-view-tooltip"


### PR DESCRIPTION
…yle string

Observed: `style="grid-area: 1-1-1; "` (The trailing semicolon and space here are suspicious). That trailing '; ' is almost certainly the problem, preventing the browser from correctly interpreting the grid-area property. The template always puts grid-area: `{{ int.stylename }};` (with the semicolon). The background-color part is only added if the cable_colors option is on and the cable has a color specified. If those conditions aren't met, the background-color part is omitted, leaving you with just `style="grid-area: 1-1-1; "` - exactly what was observed.

Explanation of the fix:

1. We remove the semicolon that was immediately after {{ int.stylename }}.
2. We add the semicolon only if the background-color property is actually being added (i.e., inside the {% if ... %} block, right before background-color).
3. This ensures that if background-color isn't added, the style attribute will correctly be style="grid-area: 1-1-1", and if it is added, it will be style="grid-area: 1-1-1; background-color: #xxxxxx".
4. Removed the unnecessary line breaks within the style attribute definition for clarity, which shouldn't affect functionality